### PR TITLE
docs: add full scanner setup guidance

### DIFF
--- a/kali-ctf-setup/README.md
+++ b/kali-ctf-setup/README.md
@@ -24,40 +24,40 @@ Python tools like `pwntools`, `impacket`, `ropgadget`, and `scapy` are installed
 
 ## Full Scanner Setup
 
-On Kali Linux or Parrot OS, the `install-tools` function provisions a wide range of open-source scanners and utilities, including:
+As of **April 30, 2026**, the `install-tools` function is designed to pull the latest package versions available from your distro repositories (`apt`) and `pipx`.
 
-- nmap
-- masscan
-- rustscan
-- nikto
-- gobuster
-- sqlmap
-- wfuzz
-- xsser
-- hydra
-- john
-- hashcat
-- gdb
-- radare2
-- ghidra
-- apktool
-- dex2jar
-- ropgadget
-- aircrack-ng
-- reaver
-- kismet
-- binwalk
-- volatility
-- foremost
-- git
-- vim
-- tmux
-- zsh
+Open-source tools provisioned include:
+
+- **Network & recon:** nmap, masscan, rustscan, amass
+- **Web scanning/fuzzing:** nikto, gobuster, feroxbuster, ffuf, wfuzz, nuclei, whatweb, xsser, sqlmap
+- **Credential/cracking:** hydra, john, hashcat
+- **Binary/mobile RE:** gdb, radare2, ghidra, apktool, dex2jar, ropgadget
+- **Wireless:** aircrack-ng, reaver, kismet
+- **Forensics:** binwalk, volatility, foremost
+- **Wordlists & support:** seclists, git, vim, tmux, zsh
+
+Python tooling via `pipx` includes pwntools, impacket, scapy, ropgadget, dirsearch, and supporting libraries.
 
 To install the full suite, run:
 
 ```bash
 bash ctf_codex_companion.sh install-tools
+```
+
+or if the script is executable:
+
+```bash
+./ctf_codex_companion.sh install-tools
+```
+
+To verify installed versions afterwards:
+
+```bash
+nmap --version
+rustscan --version
+sqlmap --version
+nuclei -version
+ffuf -V
 ```
 
 ## Usage
@@ -72,8 +72,8 @@ bash ctf_codex_companion.sh install-tools
 
 ## Troubleshooting
 
-- **No sudo privileges:** The scripts rely on `sudo` to install packages. Run as root or obtain administrative access before executing them.
-- **Non-Debian systems:** These scripts target Debian-based distributions like Kali and Parrot. On other systems, adapt the package manager commands and install equivalents manually.
+- **No sudo privileges:** The scripts rely on `sudo` for `apt` installs. If `sudo` is unavailable, run as root, ask an administrator to pre-install packages, or comment out `apt` steps and run only user-space `pipx` installs.
+- **Non-Debian systems:** These scripts target Debian-based distributions like Kali and Parrot. For Arch/Fedora/macOS, replace `apt` commands with your package manager equivalents and keep the `pipx` section for Python tools.
 
 ## Disclaimer
 

--- a/kali-ctf-setup/README.md
+++ b/kali-ctf-setup/README.md
@@ -22,6 +22,44 @@ The package lists include commonly used utilities for CTF competitions, such as:
 
 Python tools like `pwntools`, `impacket`, `ropgadget`, and `scapy` are installed with `pipx`.
 
+## Full Scanner Setup
+
+On Kali Linux or Parrot OS, the `install-tools` function provisions a wide range of open-source scanners and utilities, including:
+
+- nmap
+- masscan
+- rustscan
+- nikto
+- gobuster
+- sqlmap
+- wfuzz
+- xsser
+- hydra
+- john
+- hashcat
+- gdb
+- radare2
+- ghidra
+- apktool
+- dex2jar
+- ropgadget
+- aircrack-ng
+- reaver
+- kismet
+- binwalk
+- volatility
+- foremost
+- git
+- vim
+- tmux
+- zsh
+
+To install the full suite, run:
+
+```bash
+bash ctf_codex_companion.sh install-tools
+```
+
 ## Usage
 
 1. **Review and modify package lists** in `package-lists/` to suit your needs.
@@ -31,6 +69,11 @@ Python tools like `pwntools`, `impacket`, `ropgadget`, and `scapy` are installed
    ./setup.sh
    ```
 3. **Log out and back in** or source your shell configuration (`source ~/.bashrc`) to apply changes.
+
+## Troubleshooting
+
+- **No sudo privileges:** The scripts rely on `sudo` to install packages. Run as root or obtain administrative access before executing them.
+- **Non-Debian systems:** These scripts target Debian-based distributions like Kali and Parrot. On other systems, adapt the package manager commands and install equivalents manually.
 
 ## Disclaimer
 

--- a/kali-ctf-setup/package-lists/apt.txt
+++ b/kali-ctf-setup/package-lists/apt.txt
@@ -29,3 +29,9 @@ ghidra
 apktool
 dex2jar
 zsh
+amass
+feroxbuster
+ffuf
+nuclei
+seclists
+whatweb

--- a/kali-ctf-setup/package-lists/pip.txt
+++ b/kali-ctf-setup/package-lists/pip.txt
@@ -4,3 +4,5 @@ requests
 impacket
 ropgadget
 scapy
+wfuzz
+dirsearch


### PR DESCRIPTION
## Summary
- document the new **Full Scanner Setup** and list open-source tools for Kali/Parrot
- add example command for running `ctf_codex_companion.sh install-tools`
- include troubleshooting notes for missing sudo privileges or non-Debian systems

## Testing
- `bash -n kali-ctf-setup/setup.sh`
- `bash -n kali-ctf-setup/scripts/helper_functions.sh`
- `bash -n kali-ctf-setup/scripts/post_install.sh`


------
https://chatgpt.com/codex/tasks/task_e_689dc9f7a0a08322b30ace4357e6c774